### PR TITLE
Use normal Markdown formatting in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 This repo contains open-source datasets behind the graphics, interactives, and analyses at [Google Trends](https://www.google.com/trends). Every day we will add new datasets behind our graphics and charts. 
 
-<h3>What is the data?</h3>
-The data primarily comes from our analysis of Google Trends, but will on occasion include other Google tools such as YouTube, Play and Waze. It is primarily:<br>
-• Aggregated<br>
-• Anonymised<br>
-• Indexed<br>
-• Normalized
+### What is the data?
+The data primarily comes from our analysis of Google Trends, but will on occasion include other Google tools such as YouTube, Play and Waze. It is primarily:
 
-<h3>What can you do with it?</h3>
+- Aggregated
+- Anonymised
+- Indexed
+- Normalized
+
+### What can you do with it?
 The data is deliberately designed for you to play with, explore and create visualizations. We want to know what you do so we can share it on our social channels and inspire others to play with it too.
 
-<h3>Useful links:</h3>
-• [Google Trends](https://www.google.com/trends)<br>
-• [Google News Lab](https://www.google.com/newslab)<br>
-• [@GoogleTrends](https://www.twitter.com/googletrends)<br>
+### Useful links
+- [Google Trends](https://www.google.com/trends)
+- [Google News Lab](https://www.google.com/newslab)
+- [@GoogleTrends](https://www.twitter.com/googletrends)
 
-<h3>Contact us</h3>
+### Contact us
 newslabtrends@google.com
 


### PR DESCRIPTION
This replaces strange HTML formatting in README with ordinary Markdown formatting - most importantly, it fixes the links to Google Trends, Google News Labs and @GoogleTrends in the second list which are currently broken.