### PR TITLE
fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repo contains open-source datasets behind the graphics, interactives, and analyses at [Google Trends](https://www.google.com/trends). Every day we will add new datasets behind our graphics and charts. 
+This repo contains open-source datasets behind the graphics, interactives, and analyses at [Google Trends](https://www.google.com/trends). Every day we will add new datasets behind our graphics and charts.
 
 <h3>What is the data?</h3>
 The data primarily comes from our analysis of Google Trends, but will on occasion include other Google tools such as YouTube, Play and Waze. It is primarily:<br>
@@ -12,9 +12,8 @@ The data is deliberately designed for you to play with, explore and create visua
 
 <h3>Useful links:</h3>
 • [Google Trends](https://www.google.com/trends)<br>
-• [Google News Lab](https://www.google.com/newslab)<br>
+• [Google News Lab](https://newslab.withgoogle.com/)<br>
 • [@GoogleTrends](https://www.twitter.com/googletrends)<br>
 
 <h3>Contact us</h3>
 newslabtrends@google.com
-


### PR DESCRIPTION
#17 Fixed broken google news lab link with this working link:
https://newslab.withgoogle.com/ 