### PR TITLE
replacing tabletop.js with papa.parse

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="stylesheets/github-light.css" media="screen">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tabletop.js/1.3.5/tabletop.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.1/papaparse.min.js" integrity="sha512-EbdJQSugx0nVWrtyK3JdQQ/03mS3Q1UiAhRtErbwl1YL/+e2hZdlIcSURxxh7WXHTzn83sjlh2rysACoJGfb6g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="Pikaday/pikaday.js"></script>
     <link rel="stylesheet" type="text/css" href="Pikaday/css/pikaday.css" media="screen">
 

--- a/tableload.js
+++ b/tableload.js
@@ -23,14 +23,16 @@ function init(params) {
 
   var fromPicker, toPicker;
 
-  Tabletop.init({
-      key: key,
-      callback: loadData,
-      simpleSheet: true})
+  var spreadsheetUrl = `https://docs.google.com/spreadsheets/d/${key}/pub?output=csv`;
+  console.log(spreadsheetUrl);
+  Papa.parse(spreadsheetUrl, {
+    download: true,
+    header: true,
+    complete: loadData
+  });
 
-
-  function loadData(csv, tabletop) {
-    data = csv.map(function(d, i) {
+  function loadData(csv) {
+    data = csv.data.map(function(d, i) {
       d.id = i;
       d.date = new Date(d.date);
       return d;


### PR DESCRIPTION
google api v3 has recently been turned down. 
this website was relying on it and a js package that could load spreadsheets according to this protocol - tabletop. 
tabletop.js itself is advocating for using a similar (but actively maintained) library, Papa parse, which has a similar API but can load spreadsheet data with the google api v4 (for now). 

