### PR TITLE
Fix markdown link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 This repo contains open-source datasets behind the graphics, interactives, and analyses at [Google Trends](https://www.google.com/trends). Every day we will add new datasets behind our graphics and charts. 
 
-<h3>What is the data?</h3>
-The data primarily comes from our analysis of Google Trends, but will on occasion include other Google tools such as YouTube, Play and Waze. It is primarily:<br>
-• Aggregated<br>
-• Anonymised<br>
-• Indexed<br>
-• Normalized
+### What is the data?
+The data primarily comes from our analysis of Google Trends, but will on occasion include other Google tools such as YouTube, Play and Waze. It is primarily:
+- Aggregated
+- Anonymised
+- Indexed
+- Normalized
 
-<h3>What can you do with it?</h3>
+### What can you do with it?
 The data is deliberately designed for you to play with, explore and create visualizations. We want to know what you do so we can share it on our social channels and inspire others to play with it too.
 
-<h3>Useful links:</h3>
-• [Google Trends](https://www.google.com/trends)<br>
-• [Google News Lab](https://www.google.com/newslab)<br>
-• [@GoogleTrends](https://www.twitter.com/googletrends)<br>
+### Useful links:
+- [Google Trends](https://www.google.com/trends)
+- [Google News Lab](https://www.google.com/newslab)
+- [@GoogleTrends](https://www.twitter.com/googletrends)
 
-<h3>Contact us</h3>
-newslabtrends@google.com
+### Contact us
+[newslabtrends@google.com](mailto:newslabtrends@google.com)
 


### PR DESCRIPTION
I also changed all the headers to Markdown headers and removed line breaks. For some reason the links didn't work as expected until I did that.